### PR TITLE
Feature/32 encrypt bite2 with aad

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Run skaled container
         run: |
-          export SKALED_RELEASE=5.1.0-develop.4-bite2
+          export SKALED_RELEASE=5.1.0-develop.7-bite2
           echo "SKALED_RELEASE=$SKALED_RELEASE" >> $GITHUB_ENV
         shell: bash
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Encrypts a raw hex-encoded message using the BLS threshold encryption from the c
 
 ### `bite.encryptMessageForCTX(message, ctxSubmitterAddress)`
 
-Encrypts a raw hex-encoded message specifically for Confidential Transactions (CTX). This is a convenience method that sets the `scAddress` as `aadTE` - Additional Authentication Data for Threshold Encryption, used to protect user's encrypted data. Address of smart contract that will create CTX with that data should be passed as `ctxSubmitterAddress`. When data is encrypted with `ctxSubmitterAddress` as `aadTE`, only `ctxSubmitterAddress` is allowed to submit CTX to decrypt that data. CTXs submitted by other addresses will be rejected.
+Encrypts a raw hex-encoded message specifically for Confidential Transactions (CTX). This is a convenience method that sets the `ctxSubmitterAddress` as `aadTE` - Additional Authentication Data for Threshold Encryption, used to protect user's encrypted data. Address of smart contract that will create CTX with that data should be passed as `ctxSubmitterAddress`. When data is encrypted with `ctxSubmitterAddress` as `aadTE`, only `ctxSubmitterAddress` is allowed to submit CTX to decrypt that data. CTXs submitted by other addresses will be rejected.
 
 - **Parameters**:
   - `message`: `string` – A hex string to encrypt (with or without `0x` prefix).

--- a/README.md
+++ b/README.md
@@ -119,6 +119,17 @@ Encrypts a raw hex-encoded message using the BLS threshold encryption from the c
 
 ---
 
+### `bite.encryptMessageForCTX(message, scAddress)`
+
+Encrypts a raw hex-encoded message specifically for Confidential Transactions (CTX). This is a convenience method that sets the `scAddress` as `AADTE`.
+
+- **Parameters**:
+  - `message`: `string` – A hex string to encrypt (with or without `0x` prefix).
+  - `scAddress`: `string` – The Smart Contract Address to be used as AADTE.
+- **Returns**: `Promise<string>` – An encrypted hex string in RLP format.
+
+---
+
 ### `bite.getDecryptedTransactionData(transactionHash)`
 
 Retrieves decrypted transaction data from the configured BITE provider using the `bite_getDecryptedTransactionData` JSON-RPC method.

--- a/README.md
+++ b/README.md
@@ -119,13 +119,13 @@ Encrypts a raw hex-encoded message using the BLS threshold encryption from the c
 
 ---
 
-### `bite.encryptMessageForCTX(message, scAddress)`
+### `bite.encryptMessageForCTX(message, ctxSubmitterAddress)`
 
-Encrypts a raw hex-encoded message specifically for Confidential Transactions (CTX). This is a convenience method that sets the `scAddress` as `AADTE`.
+Encrypts a raw hex-encoded message specifically for Confidential Transactions (CTX). This is a convenience method that sets the `scAddress` as `aadTE` - Additional Authentication Data for Threshold Encryption, used to protect user's encrypted data. Address of smart contract that will create CTX with that data should be passed as `ctxSubmitterAddress`. When data is encrypted with `ctxSubmitterAddress` as `aadTE`, only `ctxSubmitterAddress` is allowed to submit CTX to decrypt that data. CTXs submitted by other addresses will be rejected.
 
 - **Parameters**:
   - `message`: `string` – A hex string to encrypt (with or without `0x` prefix).
-  - `scAddress`: `string` – The Smart Contract Address to be used as AADTE.
+  - `ctxSubmitterAddress`: `string` – The Smart Contract Address to be used as `aadTE`.
 - **Returns**: `Promise<string>` – An encrypted hex string in RLP format.
 
 ---

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "@ethereumjs/rlp": "10.0.0",
-    "@skalenetwork/t-encrypt": "0.6.0-develop.11",
+    "@skalenetwork/t-encrypt": "0.7.0-develop.0",
     "tslog": "^4.9.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skalenetwork/bite",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "TS Library to interact with BITE protocol",
   "homepage": "https://github.com/skalenetwork/bite.ts",
   "license": "LGPL-3.0-or-later",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "@ethereumjs/rlp": "10.0.0",
-    "@skalenetwork/t-encrypt": "0.6.0-develop.0",
+    "@skalenetwork/t-encrypt": "0.6.0-develop.11",
     "tslog": "^4.9.3"
   },
   "devDependencies": {

--- a/src/core/bite.ts
+++ b/src/core/bite.ts
@@ -51,6 +51,26 @@ export class BITE {
     }
 
     /**
+     * Encrypt a hex-encoded message using BLS public key for CTX.
+     * @param message - Hex string (with or without 0x).
+     * @param scAddress - Smart Contract Address for AADTE.
+     */
+    async encryptMessageForCTX(message: string, scAddress: string): Promise<string> {
+        const committees = await biteRpc.getCommitteesInfo(this.providerURL);
+        return encrypt.encryptMessage(message, committees, undefined, scAddress);
+    }
+
+    /**
+     * Encrypt a transaction object using BLS public key for CTX.
+     * @param tx - The transaction to encrypt.
+     * @param scAddress - Optional Smart Contract Address for AADTE. If not provided, tx.to will be used.
+     */
+    async encryptTransactionForCTX(tx: encrypt.Transaction, scAddress?: string): Promise<encrypt.Transaction> {
+        const committees = await biteRpc.getCommitteesInfo(this.providerURL);
+        return encrypt.encryptTransaction(tx, committees, undefined, scAddress ?? tx.to);
+    }
+
+    /**
      * Encrypt a transaction object using BLS public key and provided committees info.
      * @param tx - The transaction to encrypt.
      * @param committees - The committees info object.

--- a/src/core/bite.ts
+++ b/src/core/bite.ts
@@ -61,16 +61,6 @@ export class BITE {
     }
 
     /**
-     * Encrypt a transaction object using BLS public key for CTX.
-     * @param tx - The transaction to encrypt.
-     * @param scAddress - Optional Smart Contract Address for AADTE. If not provided, tx.to will be used.
-     */
-    async encryptTransactionForCTX(tx: encrypt.Transaction, scAddress?: string): Promise<encrypt.Transaction> {
-        const committees = await biteRpc.getCommitteesInfo(this.providerURL);
-        return encrypt.encryptTransaction(tx, committees, undefined, scAddress ?? tx.to);
-    }
-
-    /**
      * Encrypt a transaction object using BLS public key and provided committees info.
      * @param tx - The transaction to encrypt.
      * @param committees - The committees info object.

--- a/src/core/bite.ts
+++ b/src/core/bite.ts
@@ -57,7 +57,7 @@ export class BITE {
      */
     async encryptMessageForCTX(message: string, scAddress: string): Promise<string> {
         const committees = await biteRpc.getCommitteesInfo(this.providerURL);
-        return encrypt.encryptMessage(message, committees, undefined, scAddress);
+        return encrypt.encryptMessage(message, committees, scAddress);
     }
 
     /**

--- a/src/core/bite.ts
+++ b/src/core/bite.ts
@@ -53,11 +53,11 @@ export class BITE {
     /**
      * Encrypt a hex-encoded message using BLS public key for CTX.
      * @param message - Hex string (with or without 0x).
-     * @param scAddress - Smart Contract Address for AADTE.
+     * @param ctxSubmitterAddress - Smart Contract Address for aadTE.
      */
-    async encryptMessageForCTX(message: string, scAddress: string): Promise<string> {
+    async encryptMessageForCTX(message: string, ctxSubmitterAddress: string): Promise<string> {
         const committees = await biteRpc.getCommitteesInfo(this.providerURL);
-        return encrypt.encryptMessage(message, committees, scAddress);
+        return encrypt.encryptMessage(message, committees, ctxSubmitterAddress);
     }
 
     /**

--- a/src/core/encrypt.ts
+++ b/src/core/encrypt.ts
@@ -43,16 +43,16 @@ export interface Transaction {
  *
  * @param {Transaction} tx - The transaction object.
  * @param {utils.CommitteeInfo[]} committees - The committees info object.
- * @param {string} [AADAES] - Optional AES Additional Authenticated Data.
- * @param {string} [AADTE] - Optional TE Additional Authenticated Data.
+ * @param {string} [aadTE] - Optional TE Additional Authenticated Data.
+ * @param {string} [aadAES] - Optional AES Additional Authenticated Data.
  * @returns {Promise<Transaction>} - A promise with encrypted transaction.
  *
  */
 export async function encryptTransaction(
     tx: Transaction,
     committees: utils.CommitteeInfo[],
-    AADAES?: string,
-    AADTE?: string
+    aadTE?: string,
+    aadAES?: string
 ): Promise<Transaction> {
     try {
         const validatedTx = validateAndExtractTransactionFields(tx);
@@ -62,13 +62,13 @@ export async function encryptTransaction(
         // RLP encode data and to fields
         const rlpEncodedData = rlpEncodeTransactionData(txTo, txData);
 
-        const sanitizedAADAES = AADAES ? utils.remove0xPrefixIfNeeded(AADAES) : undefined;
-        const sanitizedAADTE = AADTE ? utils.remove0xPrefixIfNeeded(AADTE) : undefined;
+        const sanitizedAADAES = aadAES ? utils.remove0xPrefixIfNeeded(aadAES) : undefined;
+        const sanitizedAADTE = aadTE ? utils.remove0xPrefixIfNeeded(aadTE) : undefined;
 
         if (sanitizedAADAES) utils.validateHexString(sanitizedAADAES);
         if (sanitizedAADTE) utils.validateHexString(sanitizedAADTE);
 
-        const encryptedData = await encryptMessage(rlpEncodedData, committees, sanitizedAADAES, sanitizedAADTE);
+        const encryptedData = await encryptMessage(rlpEncodedData, committees, sanitizedAADTE, sanitizedAADAES);
 
         // Set default gasLimit if not set
         const biteGasLimit = tx.gasLimit ?? constants.DEFAULT_GAS_LIMIT;
@@ -123,22 +123,22 @@ export async function encryptTransactionMockup(tx: Transaction): Promise<Transac
  *
  * @param {string} message - The message to encrypt, as a hex string (with or without 0x prefix).
  * @param {utils.CommitteeInfo[]} committees - The committees info object.
- * @param {string} [AADAES] - Optional AES Additional Authenticated Data, as a hex string.
- * @param {string} [AADTE] - Optional TE Additional Authenticated Data, as a hex string.
+ * @param {string} [aadTE] - Optional TE Additional Authenticated Data, as a hex string.
+ * @param {string} [aadAES] - Optional AES Additional Authenticated Data, as a hex string.
  * @returns {Promise<string>} - The encrypted message.
  */
 export async function encryptMessage(
     message: string,
     committees: utils.CommitteeInfo[],
-    AADAES?: string,
-    AADTE?: string
+    aadTE?: string,
+    aadAES?: string
 ): Promise<string> {
     try {
         const data = utils.remove0xPrefixIfNeeded(message);
         utils.validateHexString(data);
 
-        const sanitizedAADAES = AADAES ? utils.remove0xPrefixIfNeeded(AADAES) : undefined;
-        const sanitizedAADTE = AADTE ? utils.remove0xPrefixIfNeeded(AADTE) : undefined;
+        const sanitizedAADTE = aadTE ? utils.remove0xPrefixIfNeeded(aadTE) : undefined;
+        const sanitizedAADAES = aadAES ? utils.remove0xPrefixIfNeeded(aadAES) : undefined;
         
         if (sanitizedAADAES) {
             utils.validateHexString(sanitizedAADAES);
@@ -149,14 +149,14 @@ export async function encryptMessage(
 
         if (committees.length === 1) {
             const publicKeyResponse = committees[0];
-            const encryptedRawMessage = await encryptRawMessage(data, publicKeyResponse.commonBLSPublicKey, sanitizedAADAES, sanitizedAADTE);
+            const encryptedRawMessage = await encryptRawMessage(data, publicKeyResponse.commonBLSPublicKey, sanitizedAADTE, sanitizedAADAES);
 
             // RLP encode epochID and encrypted message
             const rlpEncodedResult = rlpEncodeMessageData([publicKeyResponse.epochId, Buffer.from(encryptedRawMessage, 'hex')]);
             return `0x${rlpEncodedResult}`;
         } else {
-            const encryptedRawMessage = await encryptRawMessageDualKey(data, committees[0].commonBLSPublicKey, committees[1].commonBLSPublicKey, sanitizedAADAES, sanitizedAADTE);
-
+            const encryptedRawMessage = await encryptRawMessageDualKey(data, committees[0].commonBLSPublicKey,
+                committees[1].commonBLSPublicKey, sanitizedAADTE, sanitizedAADAES);
 
             // RLP encode epochID and encrypted message
             const rlpEncodedResult = rlpEncodeMessageData([committees[0].epochId, Buffer.from(encryptedRawMessage, 'hex')]);

--- a/src/core/encrypt.ts
+++ b/src/core/encrypt.ts
@@ -43,12 +43,16 @@ export interface Transaction {
  *
  * @param {Transaction} tx - The transaction object.
  * @param {utils.CommitteeInfo[]} committees - The committees info object.
+ * @param {string} [AADAES] - Optional AES Additional Authenticated Data.
+ * @param {string} [AADTE] - Optional TE Additional Authenticated Data.
  * @returns {Promise<Transaction>} - A promise with encrypted transaction.
  *
  */
 export async function encryptTransaction(
     tx: Transaction,
-    committees: utils.CommitteeInfo[]
+    committees: utils.CommitteeInfo[],
+    AADAES?: string,
+    AADTE?: string
 ): Promise<Transaction> {
     try {
         const validatedTx = validateAndExtractTransactionFields(tx);
@@ -58,7 +62,13 @@ export async function encryptTransaction(
         // RLP encode data and to fields
         const rlpEncodedData = rlpEncodeTransactionData(txTo, txData);
 
-        const encryptedData = await encryptMessage(rlpEncodedData, committees);
+        const sanitizedAADAES = AADAES ? utils.remove0xPrefixIfNeeded(AADAES) : undefined;
+        const sanitizedAADTE = AADTE ? utils.remove0xPrefixIfNeeded(AADTE) : undefined;
+
+        if (sanitizedAADAES) utils.validateHexString(sanitizedAADAES);
+        if (sanitizedAADTE) utils.validateHexString(sanitizedAADTE);
+
+        const encryptedData = await encryptMessage(rlpEncodedData, committees, sanitizedAADAES, sanitizedAADTE);
 
         // Set default gasLimit if not set
         const biteGasLimit = tx.gasLimit ?? constants.DEFAULT_GAS_LIMIT;
@@ -113,25 +123,40 @@ export async function encryptTransactionMockup(tx: Transaction): Promise<Transac
  *
  * @param {string} message - The message to encrypt, as a hex string (with or without 0x prefix).
  * @param {utils.CommitteeInfo[]} committees - The committees info object.
+ * @param {string} [AADAES] - Optional AES Additional Authenticated Data, as a hex string.
+ * @param {string} [AADTE] - Optional TE Additional Authenticated Data, as a hex string.
  * @returns {Promise<string>} - The encrypted message.
  */
 export async function encryptMessage(
     message: string,
-    committees: utils.CommitteeInfo[]
+    committees: utils.CommitteeInfo[],
+    AADAES?: string,
+    AADTE?: string
 ): Promise<string> {
     try {
         const data = utils.remove0xPrefixIfNeeded(message);
         utils.validateHexString(data);
 
+        const sanitizedAADAES = AADAES ? utils.remove0xPrefixIfNeeded(AADAES) : undefined;
+        const sanitizedAADTE = AADTE ? utils.remove0xPrefixIfNeeded(AADTE) : undefined;
+        
+        if (sanitizedAADAES) {
+            utils.validateHexString(sanitizedAADAES);
+        }
+        if (sanitizedAADTE) {
+            utils.validateHexString(sanitizedAADTE);
+        }
+
         if (committees.length === 1) {
             const publicKeyResponse = committees[0];
-            const encryptedRawMessage = await encryptRawMessage(data, publicKeyResponse.commonBLSPublicKey);
+            const encryptedRawMessage = await encryptRawMessage(data, publicKeyResponse.commonBLSPublicKey, sanitizedAADAES, sanitizedAADTE);
 
             // RLP encode epochID and encrypted message
             const rlpEncodedResult = rlpEncodeMessageData([publicKeyResponse.epochId, Buffer.from(encryptedRawMessage, 'hex')]);
             return `0x${rlpEncodedResult}`;
         } else {
-            const encryptedRawMessage = await encryptRawMessageDualKey(data, committees[0].commonBLSPublicKey, committees[1].commonBLSPublicKey);
+            const encryptedRawMessage = await encryptRawMessageDualKey(data, committees[0].commonBLSPublicKey, committees[1].commonBLSPublicKey, sanitizedAADAES, sanitizedAADTE);
+
 
             // RLP encode epochID and encrypted message
             const rlpEncodedResult = rlpEncodeMessageData([committees[0].epochId, Buffer.from(encryptedRawMessage, 'hex')]);

--- a/src/types/t-encrypt.d.ts
+++ b/src/types/t-encrypt.d.ts
@@ -1,5 +1,5 @@
 declare module '@skalenetwork/t-encrypt' {
-    export function encryptMessage(message: string, publicKey: string): Promise<string>;
-    export function encryptMessageDualKey(message: string, firstPublicKey: string, secondPublicKey: string): Promise<string>;
+    export function encryptMessage(message: string, publicKey: string, AADAES?: string, AADTE?: string): Promise<string>;
+    export function encryptMessageDualKey(message: string, firstPublicKey: string, secondPublicKey: string, AADAES?: string, AADTE?: string): Promise<string>;
     export function encryptMessageMockup(message: string): Promise<string>;
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,6 +25,7 @@ The test relies on a Solidity contract named `Game`. This contract implements a 
     *   `submitPlaintext(bytes)`: Adds plaintext data to the state.
     *   `decryptAndExecute()`: Packages the encrypted and plaintext data and performs a `staticcall` to the precompiled `submitCTX` stored at address `0x14`. The `submitCTX` precompile creates a BITE2 Transaction (Confidential Transaction - CTX), which is then added to the next block.
     *   `onDecrypt(bytes[], bytes[])`: Called as part of the execution flow to process the now-decrypted data. It calculates the sums of the values and determines if the user "won" (difference between sums < 101). Every CTX created via the `submitCTX` precompile is sent to the `onDecrypt(bytes[], bytes[])` function of the same address that initiated the call to `submitCTX`.
+    *   `didUserWin`: Returns the `userWon` flag.
 
 ## Test Steps
 
@@ -36,7 +37,7 @@ The `runSampleBITE2` function performs the following steps:
 
 2.  **Encrypted Data Submission**:
     *   Generates 5 random numbers (range 50-249).
-    *   Encrypts each number using `bite.encryptMessage(hexValue)`.
+    *   Encrypts each number using `bite.encryptMessageForCtx(hexValue, contractAddress)`.
     *   Calls `submitEncrypted` on the contract to store these values.
 
 3.  **Plaintext Data Submission**:

--- a/tests/README.md
+++ b/tests/README.md
@@ -37,7 +37,7 @@ The `runSampleBITE2` function performs the following steps:
 
 2.  **Encrypted Data Submission**:
     *   Generates 5 random numbers (range 50-249).
-    *   Encrypts each number using `bite.encryptMessageForCtx(hexValue, contractAddress)`.
+    *   Encrypts each number using `bite.encryptMessageForCTX(hexValue, contractAddress)`.
     *   Calls `submitEncrypted` on the contract to store these values.
 
 3.  **Plaintext Data Submission**:

--- a/tests/test.js
+++ b/tests/test.js
@@ -172,7 +172,7 @@ async function runSampleBITE2( providerUrl, chainID, INSECURE_ETH_PRIVATE_KEY ) 
 
         // Wait for one more block to be created
         console.log("\nStep 7: Waiting for one more block...");
-        const currentBlock = await provider.getBlockNumber();
+        let currentBlock = await provider.getBlockNumber();
         console.log(`Current block: ${currentBlock}`);
         
         // Poll for next block

--- a/tests/test.js
+++ b/tests/test.js
@@ -131,7 +131,7 @@ async function runSampleBITE2( providerUrl, chainID, INSECURE_ETH_PRIVATE_KEY ) 
         for (let i = 0; i < encryptedNumbers.length; i++) {
             const hexValue = '0x' + encryptedNumbers[i].toString(16).padStart(64, '0'); // Convert to 32 bytes hex
 
-            const encryptedNumber = await bite.encryptMessage(hexValue);
+            const encryptedNumber = await bite.encryptMessageForCTX(hexValue, contractAddress);
             
             const tx = await contract.submitEncrypted(encryptedNumber);
             await tx.wait();
@@ -176,12 +176,11 @@ async function runSampleBITE2( providerUrl, chainID, INSECURE_ETH_PRIVATE_KEY ) 
         console.log(`Current block: ${currentBlock}`);
         
         // Poll for next block
-        let nextBlock = currentBlock;
-        while (nextBlock <= currentBlock) {
+        while (currentBlock == decryptReceipt.blockNumber) {
             await new Promise(resolve => setTimeout(resolve, 1000));
-            nextBlock = await provider.getBlockNumber();
+            currentBlock = await provider.getBlockNumber();
         }
-        console.log(`✓ Next block created: ${nextBlock}`);
+        console.log(`✓ Next block created: ${currentBlock}`);
 
         // Call getSumDecrypted
         console.log("\nStep 8: Calling getSumDecrypted...");


### PR DESCRIPTION
fixes #32 

update `t-encrypt` to allow passing optional `AAD` for threshold encryption
add `encryptMessageForCTX` method
update `skaled` version in tests
update BITE2 tests
update README